### PR TITLE
Set  `matrix_forwarder_dir` to a subfolder of `matrix_forwarder_user`'s home

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 matrix_forwarder_user: centos
 matrix_forwarder_group: centos
 
-matrix_forwarder_dir: "/home/{{ matrix_forwarder_user }}"
+matrix_forwarder_dir: "/home/{{ matrix_forwarder_user }}/grafana-matrix-forwarder"
 
 matrix_forwarder_homeserver: https://matrix-client.matrix.org
 matrix_forwarder_username: "@exampleuser:matrix.org"


### PR DESCRIPTION
Set `matrix_forwarder_dir` to `"/home/{{ matrix_forwarder_user }}/grafana-matrix-forwarder"` rather than `/home/{{ matrix_forwarder_user }}`.

This prevents the task "Create folder" from changing the user's home directory permissions.

This PR is part of a series of changes targeted toward closing issue usegalaxy-eu/issues#558.