### PR TITLE
Run task "Daemon reload" as root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
   notify: daemon reload
 
 - name: Daemon reload
+  become: true
   ansible.builtin.systemd:
     daemon_reload: true
 


### PR DESCRIPTION
Run task "Daemon reload" as root to be consistent with the rest of the tasks in the role that also use `become: true` when needed.

This PR is part of a series of changes targeted toward closing issue usegalaxy-eu/issues#558.