### PR TITLE
Run task "Enable service" as root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
     daemon_reload: true
 
 - name: Enable service
+  become: true
   ansible.builtin.systemd:
     name: matrix-forwarder
     enabled: true


### PR DESCRIPTION
Run task "Enable service" as root to be consistent with the rest of the tasks in the role that also use `become: true` when needed.

This PR is part of a series of changes targeted toward closing issue usegalaxy-eu/issues#558.