### PR TITLE
Add version pinning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,13 @@
 ---
 # defaults file for grafana-matrix-forwarder
+matrix_forwarder_version: main  # a branch, or a release from https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/releases
+# beware that version tags do not always match the download URL (see examples below)
+#   - Version `v0.8.2`: Link https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/v0.8.2/grafana-matrix-forwarder-v0.8.2.zip
+#   - Version `v0.6.0`: Link https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/0.6.0/grafana-matrix-forwarder-0.6.0.zip
+# this role uses `matrix_forwarder_version` to construct the download link,
+# therefore a string matching the download link should be chosen rather than
+# the version tag
+
 matrix_forwarder_user: centos
 matrix_forwarder_group: centos
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,13 +19,13 @@
 
 - name: Get files
   ansible.builtin.unarchive:
-    src: https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/main/grafana-matrix-forwarder-main.zip
+    src: https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/{{ matrix_forwarder_version }}/grafana-matrix-forwarder-{{ matrix_forwarder_version }}.zip
     dest: "{{ matrix_forwarder_dir }}"
     remote_src: yes
 
 - name: Compile the app from src
   ansible.builtin.command:
-    chdir: "{{ matrix_forwarder_dir }}/grafana-matrix-forwarder-main/src"
+    chdir: "{{ matrix_forwarder_dir }}/grafana-matrix-forwarder-{{ matrix_forwarder_version }}/src"
     cmd: go build app.go
 
 - name: C""

--- a/templates/matrix-forwarder.service.j2
+++ b/templates/matrix-forwarder.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ matrix_forwarder_user }}
 Group={{ matrix_forwarder_group }}
-ExecStart=/{{ matrix_forwarder_dir }}grafana-matrix-forwarder-main/src/app --user {{ matrix_forwarder_username }} \
+ExecStart=/{{ matrix_forwarder_dir }}grafana-matrix-forwarder-{{ matrix_forwarder_version }}/src/app --user {{ matrix_forwarder_username }} \
   --password {{ matrix_forwarder_password }} --homeserver {{ matrix_forwarder_homeserver }} \
   -metricRounding {{ matrix_forwarder_metric_rounding }} -port {{ matrix_forwarder_port }} \
   -host {{ matrix_forwarder_host }} -resolveMode {{ matrix_forwarder_resolve_mode }}


### PR DESCRIPTION
Introduce a variable `matrix_forwarder_version` that allows to choose which version of Grafana to Matrix Forwarder should be installed.

This PR is part of a series of changes targeted toward closing issue usegalaxy-eu/issues#558.