### PR TITLE
Changes to `ExecStart` path on matrix-forwarder.service.j2

### DIFF
--- a/templates/matrix-forwarder.service.j2
+++ b/templates/matrix-forwarder.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User={{ matrix_forwarder_user }}
 Group={{ matrix_forwarder_group }}
-ExecStart=/{{ matrix_forwarder_dir }}grafana-matrix-forwarder-main/src/app --user {{ matrix_forwarder_username }} \
+ExecStart={{ matrix_forwarder_dir }}/grafana-matrix-forwarder-main/src/app --user {{ matrix_forwarder_username }} \
   --password {{ matrix_forwarder_password }} --homeserver {{ matrix_forwarder_homeserver }} \
   -metricRounding {{ matrix_forwarder_metric_rounding }} -port {{ matrix_forwarder_port }} \
   -host {{ matrix_forwarder_host }} -resolveMode {{ matrix_forwarder_resolve_mode }}


### PR DESCRIPTION
- Remove initial "/". If the user has entered a relative path, it should not be treated as an absolute path. systemd will take care of letting the user know that something is wrong.

> For each command, the first argument must be either an absolute path to an executable or a simple file name without any slashes. If the command is not a full (absolute) path, it will be resolved to a full path using a fixed search path determined at compilation time. Searched directories include /usr/local/bin/, /usr/bin/, /bin/ on systems using split /usr/bin/ and /bin/ directories, and their sbin/ counterparts on systems using split bin/ and sbin/. It is thus safe to use just the executable name in case of executables located in any of the "standard" directories, and an absolute path must be used in other cases. Hint: this search path may be queried using systemd-path search-binaries-default.
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines

- Add "/" after `{{ matrix_forwarder_dir }}`. It should not be assumed that the user will include it (see https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13) and paths with duplicate slashes are valid.

This PR is part of a series of changes targeted toward closing issue usegalaxy-eu/issues#558.