### PR TITLE
Update Ansible Lint GitHub action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,4 @@ jobs:
         uses: ibiqlik/action-yamllint@v3
 
       - name: Run ansible-lint
-        # replace `main` with any valid ref, or tags like `v6`
-        uses: ansible-community/ansible-lint-action@main
+        uses: ansible/ansible-lint@v24


### PR DESCRIPTION
Switch from ansible-community/ansible-lint-action (now unmaintained) to ansible/ansible-lint (v24).

This PR is part of a series of changes targeted toward closing issue usegalaxy-eu/issues#558.