### PR TITLE
Fix var-naming[no-role-prefix] Ansible Lint issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Role Variables
 --------------
 
 Most variables are self-explaining, or meanings can be found in the [repo](https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/tree/main/).
-Please make sure that your `matrix_forwarder_password` goes to an ansible-vault.  
-`matrix_forwarder_systemd_user` is the system-user, wheras `matrix_forwarder_username` is the matrix username.
+Please make sure that your `grafana_matrix_forwarder_password` goes to an ansible-vault.  
+`grafana_matrix_forwarder_systemd_user` is the system-user, wheras `grafana_matrix_forwarder_username` is the matrix username.
 
 Dependencies
 ------------
@@ -29,8 +29,8 @@ Including an example of how to use your role (for instance, with variables passe
       roles:
          - name: usegalaxy_eu.grafana_matrix_forwarder
            vars:
-             - matrix_forwarder_systemd_user: galaxy
-             - matrix_forwarder_systemd_group: galaxy
+             - grafana_matrix_forwarder_systemd_user: galaxy
+             - grafana_matrix_forwarder_systemd_group: galaxy
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-matrix_forwarder_version: main  # a branch, or a release from https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/releases
+grafana_matrix_forwarder_version: main  # a branch, or a release from https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/releases
 # beware that version tags do not always match the download URL (see examples below)
 #   - Version `v0.8.2`: Link https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/v0.8.2/grafana-matrix-forwarder-v0.8.2.zip
 #   - Version `v0.6.0`: Link https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/0.6.0/grafana-matrix-forwarder-0.6.0.zip
@@ -8,21 +8,21 @@ matrix_forwarder_version: main  # a branch, or a release from https://gitlab.com
 # the version tag
 
 # Path of the Grafana Matrix Forwarder binary
-matrix_forwarder_path: /usr/local/bin/grafana-matrix-forwarder
+grafana_matrix_forwarder_path: /usr/local/bin/grafana-matrix-forwarder
 
 # Owner, group, mode of the Grafana Matrix Forwarder binary
 # matrix_forwarder_owner: omit
 # matrix_forwarder_group: omit
-matrix_forwarder_mode: "0755"
+grafana_matrix_forwarder_mode: "0755"
 
 # Systemd service unit
-matrix_forwarder_systemd_user: root
-matrix_forwarder_systemd_group: root 
+grafana_matrix_forwarder_systemd_user: root
+grafana_matrix_forwarder_systemd_group: root 
 # application configuration (parameters in systemd unit)
-matrix_forwarder_homeserver: https://matrix-client.matrix.org
-matrix_forwarder_username: "@exampleuser:matrix.org"
-matrix_forwarder_password: I_go_to_VAULT!
-matrix_forwarder_port: 6000
-matrix_forwarder_metric_rounding: 1
-matrix_forwarder_resolve_mode: message # choose from 'message', 'reaction' and 'reply'
-matrix_forwarder_host: 0.0.0.0
+grafana_matrix_forwarder_homeserver: https://matrix-client.matrix.org
+grafana_matrix_forwarder_username: "@exampleuser:matrix.org"
+grafana_matrix_forwarder_password: I_go_to_VAULT!
+grafana_matrix_forwarder_port: 6000
+grafana_matrix_forwarder_metric_rounding: 1
+grafana_matrix_forwarder_resolve_mode: message # choose from 'message', 'reaction' and 'reply'
+grafana_matrix_forwarder_host: 0.0.0.0

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,7 +7,7 @@
       ansible.builtin.include_role:
         name: "usegalaxy_eu.grafana_matrix_forwarder"
       vars:
-        matrix_forwarder_systemd_user: root
-        matrix_forwarder_systemd_group: root
-        # matrix_forwarder_version: "v0.8.2"  # (compiles on the root of the archive)
-        matrix_forwarder_version: "0.6.0"  # (compiles on the "src" subdirectory)
+        grafana_matrix_forwarder_systemd_user: root
+        grafana_matrix_forwarder_systemd_group: root
+        # grafana_matrix_forwarder_version: "v0.8.2"  # (compiles on the root of the archive)
+        grafana_matrix_forwarder_version: "0.6.0"  # (compiles on the "src" subdirectory)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     - name: Download and extract source code.
       ansible.builtin.unarchive:
         remote_src: true
-        src: "https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/{{ matrix_forwarder_version }}/grafana-matrix-forwarder-{{ matrix_forwarder_version }}.zip"
+        src: "https://gitlab.com/hectorjsmith/grafana-matrix-forwarder/-/archive/{{ grafana_matrix_forwarder_version }}/grafana-matrix-forwarder-{{ grafana_matrix_forwarder_version }}.zip"
         dest: "{{ __grafana_matrix_forwarder_tempdir.path }}"
       changed_when: false
 
@@ -27,7 +27,7 @@
       block:
         - name: Assume the compiler should be run on the root directory of the archive.
           ansible.builtin.set_fact:
-            __grafana_matrix_forwarder_compilation_directory: "{{ __grafana_matrix_forwarder_tempdir.path }}/grafana-matrix-forwarder-{{ matrix_forwarder_version }}"
+            __grafana_matrix_forwarder_compilation_directory: "{{ __grafana_matrix_forwarder_tempdir.path }}/grafana-matrix-forwarder-{{ grafana_matrix_forwarder_version }}"
 
         - name: Check if the "src" subdirectory exists.
           ansible.builtin.stat:
@@ -49,7 +49,7 @@
 
     - name: Check whether a binary exists in the configured path.
       ansible.builtin.stat:
-        path: "{{ matrix_forwarder_path }}"
+        path: "{{ grafana_matrix_forwarder_path }}"
       register: __grafana_matrix_forwarder_path_exists
 
     - name: Compare the sha256sums of the installed binary and the compiled one.
@@ -60,7 +60,7 @@
           executable: /bin/bash
           cmd: |
             set -o pipefail
-            sha256sum {{ matrix_forwarder_path }}  | cut -d ' ' -f 1
+            sha256sum {{ grafana_matrix_forwarder_path }}  | cut -d ' ' -f 1
         register: __grafana_matrix_forwarder_sha256sum_installed
         changed_when: false
 
@@ -82,10 +82,10 @@
       ansible.builtin.copy:
         remote_src: true
         src: "{{ __grafana_matrix_forwarder_compilation_directory }}/app"
-        dest: "{{ matrix_forwarder_path }}"
-        owner: "{{ matrix_forwarder_owner | default(omit) }}"
-        group: "{{ matrix_forwarder_group | default(omit) }}"
-        mode: "{{ matrix_forwarder_mode | default('0755') }}"
+        dest: "{{ grafana_matrix_forwarder_path }}"
+        owner: "{{ grafana_matrix_forwarder_owner | default(omit) }}"
+        group: "{{ grafana_matrix_forwarder_group | default(omit) }}"
+        mode: "{{ grafana_matrix_forwarder_mode | default('0755') }}"
       when: __grafana_matrix_forwarder_install | default(true)
       # install the binary only when the two sha256sums differ (and therefore,
       # report no changes when the complied binary is identical)

--- a/templates/matrix-forwarder.service.j2
+++ b/templates/matrix-forwarder.service.j2
@@ -3,12 +3,12 @@ Description=Grafana Matrix Forwarder
 After=network.target
 
 [Service]
-User={{ matrix_forwarder_systemd_user }}
-Group={{ matrix_forwarder_systemd_group }}
-ExecStart={{ matrix_forwarder_path }} --user {{ matrix_forwarder_username }} \
-  --password {{ matrix_forwarder_password }} --homeserver {{ matrix_forwarder_homeserver }} \
-  -metricRounding {{ matrix_forwarder_metric_rounding }} -port {{ matrix_forwarder_port }} \
-  -host {{ matrix_forwarder_host }} -resolveMode {{ matrix_forwarder_resolve_mode }}
+User={{ grafana_matrix_forwarder_systemd_user }}
+Group={{ grafana_matrix_forwarder_systemd_group }}
+ExecStart={{ grafana_matrix_forwarder_path }} --user {{ grafana_matrix_forwarder_username }} \
+  --password {{ grafana_matrix_forwarder_password }} --homeserver {{ grafana_matrix_forwarder_homeserver }} \
+  -metricRounding {{ grafana_matrix_forwarder_metric_rounding }} -port {{ grafana_matrix_forwarder_port }} \
+  -host {{ grafana_matrix_forwarder_host }} -resolveMode {{ grafana_matrix_forwarder_resolve_mode }}
 Restart=on-failure
 KillMode=control-group
 


### PR DESCRIPTION
Rename role variables so that they comply with the var-naming[no-role-prefix] rule. See https://ansible.readthedocs.io/projects/lint/rules/var-naming/ for more information.

This PR is part of a series of changes targeted toward closing issue usegalaxy-eu/issues#558.